### PR TITLE
Add brew service installation

### DIFF
--- a/cli/stubs/schema.json
+++ b/cli/stubs/schema.json
@@ -59,6 +59,12 @@
                     }
                 }
             }
+        },
+        "services": {
+            "type": "array",
+            "contains": {
+                "type": "string"
+            }
         }
     },
     "required": ["sites", "hooks"]

--- a/tests/fixtures/Parked/Sites/Single/single-taxi-site/taxi.json
+++ b/tests/fixtures/Parked/Sites/Single/single-taxi-site/taxi.json
@@ -26,5 +26,9 @@
       "composer install",
       "npm run production"
     ]
-  }
+  },
+  "services": [
+    "mariadb@10.7",
+    "redis"
+  ]
 }


### PR DESCRIPTION
Add an optional array to `taxi.json` configuration file

```
  "hooks": {
   ...
  },
  "services": [
    "mariadb@10.7",
    "redis"
  ]
}
```

Allows for specific services to be installed, provided they exists and are not already installed.